### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: clojure
+script: lein jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: clojure
-script: lein jar
+script: sh test-template.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # aws-lambda-serverless
 
+[![Build Status](https://travis-ci.org/jsyrjala/aws-lambda-serverless.svg?branch=master)](https://travis-ci.org/jsyrjala/aws-lambda-serverless)
+
 A Leiningen template for creating a [AWS Lambda](https://aws.amazon.com/lambda/) 
 that gets deployed with [Serverless](https://serverless.com/).
 

--- a/resources/leiningen/new/aws_lambda_serverless/README.md
+++ b/resources/leiningen/new/aws_lambda_serverless/README.md
@@ -35,7 +35,6 @@ Creating stack
 ```
 npm i -g serverless
 lein uberjar
-cd serverless
 serverless deploy -v --stack dev
 ```
 

--- a/test-template.sh
+++ b/test-template.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash -e
+# - Create the template
+# - Create a project based on the template
+# - Build the project
+# - Run uberjar
+
+echo lein jar
+lein jar
+
+cd target
+
+echo
+echo lein new aws-lambda-serverless my-project
+lein new aws-lambda-serverless my-project
+
+cd my-project
+
+echo
+echo lein uberjar
+lein uberjar
+
+echo
+echo java -jar target/my-project-0.1.0-SNAPSHOT-standalone.jar
+java -jar target/my-project-0.1.0-SNAPSHOT-standalone.jar


### PR DESCRIPTION
Adds https://travis-ci.org build that uses to template to create a project and checks that resulting project builds.

Fixes #5.