### PR TITLE
Add a comment to `region` attribute in `provider` definition

### DIFF
--- a/resources/leiningen/new/aws_lambda_serverless/serverless.yml
+++ b/resources/leiningen/new/aws_lambda_serverless/serverless.yml
@@ -8,7 +8,7 @@ provider:
   name: aws
   runtime: java8
   # role: TODO add role
-  region: eu-central-1
+  region: eu-central-1 # TODO make sure this is the region you want
 
 package:
   artifact: target/{{name}}-0.1.0-SNAPSHOT-standalone.jar


### PR DESCRIPTION
For me personally it was surprising that the region is not taken from env variables first. IMHO it should at least be commented with a TODO or a FIXME.